### PR TITLE
Add `perspective`-based grouping function

### DIFF
--- a/README.org
+++ b/README.org
@@ -104,7 +104,7 @@ To get started, customize this variable:
 ** Grouping popups by context
 Popper can group popups by "context", so that the popups available for display are limited to those that are relevant to the context in which =popper-toggle-latest= or =popper-cycle= is called. For example, when cycling popups from a project buffer, you may only want to see the popups (REPLs, help buffers and compilation output, say) that were spawned from buffers in that project. This is intended to approximate DWIM behavior, so that the most relevant popup in any context is never more than one command away.
 
-Built in contexts include projects as defined in Emacs' built in =project.el= and =projectile=, as well as the default directory of a buffer. To set this, customize =popper-group-function= or use one of
+Built in contexts include projects as defined in Emacs' built in =project.el= and =projectile=, using =perspective= names, as well as the default directory of a buffer. To set this, customize =popper-group-function= or use one of
 
 #+BEGIN_SRC emacs-lisp
   (setq popper-group-function #'popper-group-by-project) ; project.el projects
@@ -115,6 +115,7 @@ Built in contexts include projects as defined in Emacs' built in =project.el= an
                                                            ; project root, with
                                                            ; fall back to
                                                            ; default-directory
+  (setq popper-group-function #'popper-group-by-perspective) ; group by perspective
 #+END_SRC
 
 You can also provide a custom function that takes no arguments, is executed in the context of a popup buffer and returns a string or symbol that represents the group/context it belongs to. This function will group all popups under the symbol =my-popup-group=:

--- a/popper.el
+++ b/popper.el
@@ -73,6 +73,7 @@
 (declare-function project-root "project")
 (declare-function project-current "project")
 (declare-function projectile-project-root "projectile")
+(declare-function persp-current-name "perspective")
 
 (defvar popper-mode)
 
@@ -151,12 +152,14 @@ Built-in choices include
 
 `popper-group-by-directory': Return project root or default directory.
 `popper-group-by-project': Return project root using project.el.
-`popper-group-by-projectile': Return project root using projectile."
+`popper-group-by-projectile': Return project root using projectile.
+`popper-group-by-perspective': Return perspective name."
   :group 'popper
   :type '(choice
           (const :tag "Don't group popups" nil)
           (const :tag "Group by project (project.el)" popper-group-by-project)
           (const :tag "Group by project (projectile)" popper-group-by-projectile)
+		  (const :tag "Group by perspective" popper-group-by-perspective)
           (const :tag "Group by directory" popper-group-by-directory)
           (function :tag "Custom function")))
 
@@ -242,6 +245,16 @@ This returns the project root found using the projectile package."
   Please install `projectile' or customize
   `popper-group-function'"))
   (projectile-project-root))
+
+(defun popper-group-by-perspective ()
+  "Return an identifier to group popups.
+
+This returns the name of the perspective."
+  (unless (fboundp 'persp-current-name)
+	(user-error "Cannot find perspective name to group popups.
+  Please install `perspective' or customize
+  `popper-group-function'"))
+  (persp-current-name))
 
 (defun popper-find-popups (test-buffer-list)
   "Return an alist corresponding to popups in TEST-BUFFER-LIST.

--- a/popper.el
+++ b/popper.el
@@ -159,7 +159,7 @@ Built-in choices include
           (const :tag "Don't group popups" nil)
           (const :tag "Group by project (project.el)" popper-group-by-project)
           (const :tag "Group by project (projectile)" popper-group-by-projectile)
-		  (const :tag "Group by perspective" popper-group-by-perspective)
+          (const :tag "Group by perspective" popper-group-by-perspective)
           (const :tag "Group by directory" popper-group-by-directory)
           (function :tag "Custom function")))
 
@@ -251,7 +251,7 @@ This returns the project root found using the projectile package."
 
 This returns the name of the perspective."
   (unless (fboundp 'persp-current-name)
-	(user-error "Cannot find perspective name to group popups.
+    (user-error "Cannot find perspective name to group popups.
   Please install `perspective' or customize
   `popper-group-function'"))
   (persp-current-name))


### PR DESCRIPTION
Adds a group function for fellow https://github.com/nex3/perspective-el people.

Might be too trivial and narrow an audience, but I usually like grouping buffers by perspective, not project (I often work on projects that are closely related and share a perspective in my workflow), and have been using this one since I started using your awesome package.