### PR TITLE
[WIP] Treat some buffers as hidden by default

### DIFF
--- a/popper.el
+++ b/popper.el
@@ -215,7 +215,7 @@ grouped by the predicate `popper-group-function'.")
       (when (or (and (stringp hidden)
                      (string-match-p hidden (buffer-name buffer)))
                 (and (symbolp hidden)
-                     (eq (buffer-local-value 'major-mode buffer))))
+                     (eq (buffer-local-value 'major-mode buffer) hidden)))
         (throw 'done t)))))
 
 (defun popper-select-popup-at-bottom-maybe-hide (buffer &optional _alist)

--- a/popper.el
+++ b/popper.el
@@ -100,7 +100,14 @@ Output*, and all help and compilation buffers."
   :group 'popper)
 
 (defcustom popper-reference-hidden-buffers '()
-  ""
+  "List of buffers to treat as hidden popups.
+
+This elements of this list take the same format as in
+`popper-reference-buffers'. When the value of
+`popper-display-function' is set to
+`popper-select-popup-at-bottom-maybe-hide', the buffers in this
+list will not be shown by default unless explicitly asked for via
+a function like `popper-toggle-latest'. "
   :type '(restricted-sexp :match-alternatives (stringp symbolp))
   :group 'popper)
 
@@ -210,6 +217,7 @@ grouped by the predicate `popper-group-function'.")
     (select-window window)))
 
 (defun popper-hidden-buffer-p (buffer)
+  "Check if BUFFER matches a buffer in `popper-reference-hidden-buffers'."
   (catch 'done
     (dolist (hidden popper-reference-hidden-buffers nil)
       (when (or (and (stringp hidden)
@@ -221,7 +229,8 @@ grouped by the predicate `popper-group-function'.")
 (defun popper-select-popup-at-bottom-maybe-hide (buffer &optional _alist)
   "Display and switch to popup-buffer BUFFER at the bottom of the screen.
 
-Hide buffers in `popper-reference-buffers-hidden'."
+Don't show the buffer automatically if it is listed in
+`popper-reference-buffers-hidden'."
   (if (and (popper-hidden-buffer-p buffer)
            (null popper-calling-display-buffer))
       (display-buffer-no-window buffer '((allow-no-window . t)))

--- a/popper.el
+++ b/popper.el
@@ -312,20 +312,20 @@ Each element of the alist is a cons cell of the form (window . buffer)."
          (open-popups (cl-remove-if-not
                        (lambda (win-buf) (windowp (car win-buf)))
                        popups))
-         (closed-popups (cl-set-difference popups open-popups :key #'cdr))
-         buried-alist)
+         (closed-popups (cl-set-difference popups open-popups :key #'cdr)))
     (setq popper-open-popup-alist (nreverse open-popups))
+    (setq popper-buried-popup-alist nil)
     (if popper-group-function
         (cl-loop for (win . buf) in closed-popups do
                  (let ((group (with-current-buffer buf
                                 (funcall popper-group-function)))
                        (newelt (cons win buf)))
-                   (if (alist-get group buried-alist)
-                       (push newelt (alist-get group buried-alist))
-                     (push (cons group (list newelt)) buried-alist)))
-                 finally
-                 (setq popper-buried-popup-alist buried-alist))
-      (setq popper-buried-popup-alist closed-popups)))
+                   (if (alist-get group popper-buried-popup-alist)
+                       (push newelt (alist-get group
+                                               popper-buried-popup-alist))
+                     (push (cons group (list newelt))
+                           popper-buried-popup-alist))))
+      (setq popper-buried-popup-alist (list (cons nil closed-popups)))))
   ;; Mode line update
   (cl-loop for (_ . buf) in popper-open-popup-alist do
            (with-current-buffer buf

--- a/popper.el
+++ b/popper.el
@@ -186,6 +186,9 @@ grouped by the predicate `popper-group-function'.")
 (defvar popper-lighter ""
   "Lighter for `popper-mode'.")
 
+(defvar popper-calling-display-buffer nil
+  "Flag to track when popper is explicitly calling `display-buffer'.")
+
 (defvar-local popper-popup-status nil
   "Identifies a buffer as a popup by its buffer-local value.
   Valid values are 'popup, 'raised, 'user-popup or nil.
@@ -219,7 +222,8 @@ grouped by the predicate `popper-group-function'.")
   "Display and switch to popup-buffer BUFFER at the bottom of the screen.
 
 Hide buffers in `popper-reference-buffers-hidden'."
-  (if (popper-hidden-buffer-p buffer)
+  (if (and (popper-hidden-buffer-p buffer)
+           (null popper-calling-display-buffer))
       (display-buffer-no-window buffer '((allow-no-window . t)))
     (let ((window (display-buffer-in-side-window
                    buffer
@@ -391,7 +395,8 @@ a popup buffer to open."
                                            nil 'remove 'equal)))
                 (buf (cdr new-popup)))
           (if (buffer-live-p buf)
-              (progn (display-buffer buf))
+              (let ((popper-calling-display-buffer t))
+                (display-buffer buf))
             (popper-open-latest))
         (message no-popup-msg)))))
 

--- a/popper.el
+++ b/popper.el
@@ -178,6 +178,9 @@ Built-in choices include
 If `popper-group-function' is non-nil, these are
 grouped by the predicate `popper-group-function'.")
 
+(defvar popper-lighter ""
+  "Lighter for `popper-mode'.")
+
 (defvar-local popper-popup-status nil
   "Identifies a buffer as a popup by its buffer-local value.
   Valid values are 'popup, 'raised, 'user-popup or nil.
@@ -516,7 +519,7 @@ dismissed with a command. See the customization options for
 details on how to designate buffer types as popups."
   :global t
   :version "0.30"
-  :lighter ""
+  :lighter popper-lighter
   :group 'popper
   :keymap (let ((map (make-sparse-keymap))) map)
   (if popper-mode


### PR DESCRIPTION
I messed around with the logic in `popper-update-popups` to get this to work, allowing it to be used from `buffer-update-list-hook`. It seems ok, but I might have broken something else unintentionally. 

The main idea is that hidden buffers should be added to `popper-reference-hidden-buffers` and that these buffers should not show by default, but can be showed manually through `popper-toggle-latest` and the like. For this to work, you also need to set `popper-display-function` to `popper-select-popup-at-bottom-maybe-hide`. 

I also added a lighter variable with the intention of being able to indicate when a buffer that is hidden tried to popup, but I haven't implemented it yet. 