### PR TITLE
extract window height determining function

### DIFF
--- a/popper.el
+++ b/popper.el
@@ -186,14 +186,17 @@ grouped by the predicate `popper-group-function'.")
 'raised    : This is a POPUP buffer raised to regular status by the user.
 'user-popup: This is a regular buffer lowered to popup status by the user.")
 
+(defun popper-determine-window-height (win)
+  "Determine the popper window height by fitting it to the buffer's content."
+  (fit-window-to-buffer
+   win
+   (floor (frame-height) 3)))
+
 (defun popper-select-popup-at-bottom (buffer &optional _alist)
   "Display and switch to popup-buffer BUFFER at the bottom of the screen."
   (let ((window (display-buffer-in-side-window
                  buffer
-                 '((window-height . (lambda (win)
-                                      (fit-window-to-buffer
-                                       win
-                                       (floor (frame-height) 3))))
+                 '((window-height . popper-determine-window-height)
                    (side . bottom)
                    (slot . 1)))))
     (select-window window)))

--- a/popper.el
+++ b/popper.el
@@ -237,7 +237,8 @@ directory as a fall back."
     (user-error "Cannot find project directory to group popups.
   Please install `project' or customize
   `popper-group-function'"))
-  (project-root (project-current)))
+  (when-let ((project (project-current)))
+    (project-root project)))
 
 (defun popper-group-by-projectile ()
   "Return an identifier to group popups.


### PR DESCRIPTION
Thanks for this package. I was able to easily replicate and drop my custom `display-buffer-alist` customization without much effort.

I don't need to use Shackle and I am only using the default of using poppers `popper-select-popup-at-bottom`. The only change I would like to make personally is have the popup at the bottom of the window be a fixed percentage of the frame's height, instead of fit to the popped buffer's content. By just extracting the function that determines the window height, it makes it easier to override or replace the function with advice.

Alternately, the alist of side window parameters could become a `defcustom` target.