### PR TITLE
Set a minimum window size

### DIFF
--- a/popper.el
+++ b/popper.el
@@ -193,7 +193,8 @@ grouped by the predicate `popper-group-function'.")
                  '((window-height . (lambda (win)
                                       (fit-window-to-buffer
                                        win
-                                       (floor (frame-height) 3))))
+                                       (floor (frame-height) 3)
+                                       (floor (frame-height) 6))))
                    (side . bottom)
                    (slot . 1)))))
     (select-window window)))


### PR DESCRIPTION
When using terminal windows as popups, it can be the case where i toggle a popup and when it returns it is one line high, because that was the size of the terminal when i closed it. Compile buffers can also start of being about 4 lines long which is also quite small. Perhaps it might make sense to set a lower bound on the size of popup windows so that any window that comes back will be a reasonable size?

I don't know there may be cases where there is a legitimate 1 line sized window, but it's also true that when toggling these windows, it's good to make them somewhat visible.  So i choose a divisor of 6 to make the minimum size 50% of the maximum size.  in my case it ends up being about 9 lines minimum usually, and 18 lines max.

What do you think?

I think this is related to https://github.com/karthink/popper/pull/8 because one case where we want a fixed size is that the minimum is so small that you can't use the buffer in it's default size