### PR TITLE
Fix error in `popper-group-by-project`

### DIFF
--- a/popper.el
+++ b/popper.el
@@ -235,7 +235,8 @@ directory as a fall back."
     (user-error "Cannot find project directory to group popups.
   Please install `project' or customize
   `popper-group-function'"))
-  (project-root (project-current)))
+  (when-let ((project (project-current)))
+    (project-root project)))
 
 (defun popper-group-by-projectile ()
   "Return an identifier to group popups.


### PR DESCRIPTION
`project-root` throws an error if given nil as an argument. This change
corrects the behavior.