### PR TITLE
Fix #29: Error while modifying mode line.

### DIFF
--- a/popper.el
+++ b/popper.el
@@ -467,10 +467,11 @@ a popup buffer to open."
   (when (and popper-mode-line mode-line-format)
     (if (member popper-mode-line mode-line-format)
         mode-line-format
-      (append (cl-subseq (default-value 'mode-line-format) 0 popper-mode-line-position)
-              (list popper-mode-line
-                    (nthcdr popper-mode-line-position
-                            (default-value 'mode-line-format)))))))
+      (and (listp mode-line-format)
+           (append (cl-subseq (default-value 'mode-line-format) 0 popper-mode-line-position)
+                   (list popper-mode-line
+                         (nthcdr popper-mode-line-position
+                                 (default-value 'mode-line-format))))))))
 
 (defun popper--restore-mode-lines (win-buf-alist)
   "Restore the default value of `mode-line-format'.

--- a/popper.el
+++ b/popper.el
@@ -464,14 +464,14 @@ a popup buffer to open."
 
 (defun popper--modified-mode-line ()
   "Return modified mode-line string."
-  (when (and popper-mode-line mode-line-format)
-    (if (member popper-mode-line mode-line-format)
-        mode-line-format
-      (and (listp mode-line-format)
-           (append (cl-subseq (default-value 'mode-line-format) 0 popper-mode-line-position)
-                   (list popper-mode-line
-                         (nthcdr popper-mode-line-position
-                                 (default-value 'mode-line-format))))))))
+  (if (and popper-mode-line (consp mode-line-format))
+      (if (member popper-mode-line mode-line-format)
+          mode-line-format
+        (append (cl-subseq (default-value 'mode-line-format) 0 popper-mode-line-position)
+                (list popper-mode-line
+                      (nthcdr popper-mode-line-position
+                              (default-value 'mode-line-format)))))
+    mode-line-format))
 
 (defun popper--restore-mode-lines (win-buf-alist)
   "Restore the default value of `mode-line-format'.

--- a/popper.el
+++ b/popper.el
@@ -464,7 +464,7 @@ a popup buffer to open."
 
 (defun popper--modified-mode-line ()
   "Return modified mode-line string."
-  (when popper-mode-line
+  (when (and popper-mode-line mode-line-format)
     (if (member popper-mode-line mode-line-format)
         mode-line-format
       (append (cl-subseq (default-value 'mode-line-format) 0 popper-mode-line-position)
@@ -647,7 +647,7 @@ If BUFFER is not specified act on the current buffer instead."
                  ('mode (cl-pushnew (car elm) popper--suppressed-modes))
                  ('pred (cl-pushnew (car elm) popper--suppressed-predicates))))
              (popper--insert-type (car elm)))))
-  
+
   (dolist (entry popper-reference-buffers nil)
     (popper--insert-type entry)))
 


### PR DESCRIPTION
If mode-line-format is nil or not a list, the error occurs while modifying the mode-line-format.
e.g. put "\\*Calendar\\*" in popper-reference-buffers.

Fix #29.