### PR TITLE
fix the use-package config

### DIFF
--- a/README.org
+++ b/README.org
@@ -105,6 +105,7 @@ If you want the echo-area hints, turn on =popper-echo-mode=.
             "\\*Async Shell Command\\*"
             help-mode
             compilation-mode))
+    :config
     (popper-mode +1)
     (popper-echo-mode +1))                ; For echo area hints
 #+END_SRC


### PR DESCRIPTION
The `use-package` syntax has a mistake,  enabling the popper modes without `:config` would result in:

```
Error (use-package): popper/:init: Symbol’s function definition is void: popper-mode 
```

Searching lead me to [a comment](https://github.com/politza/pdf-tools/issues/206#issuecomment-614885793) which clarified the issue. I confirmed it with [the `use-package` manual](https://github.com/jwiegley/use-package#getting-started).