### PR TITLE
Add 'unmodified option to popper-mode-line

### DIFF
--- a/README.org
+++ b/README.org
@@ -290,7 +290,7 @@ You can combine the hiding feature with predicates for classifying buffers as po
 This assignment will suppress display of the async shell command output buffer, but only when there is no output (stdout). Once it is hidden it will be treated as a popup on par with other entries in =popper-reference-buffers=.
 
 ** Mode line and Echo area customization 
-- To change the modeline string used by Popper (the default is "POP"), customize =popper-mode-line=. You can disable the modeline entirely by setting it to nil.
+- To change the modeline string used by Popper (the default is "POP"), customize =popper-mode-line=. You can disable the modeline entirely by setting it to nil or set to ='unmodified= to disable modeline modifications.
 - You can change the keys used to access popups when using =popper-echo-mode= by customizing the =popper-echo-dispatch-keys= variable. To retain the display while removing the keymap, set this variable to =nil=.
 - You can change the number of minibuffer lines used for display by =popper-echo-mode= by customizing =popper-echo-lines=.
 - If you want to change the buffer names displayed in the echo area in some way (such as to color them by mode or truncate long names), you can customize the variable =popper-echo-transform-function=.

--- a/popper.el
+++ b/popper.el
@@ -52,7 +52,7 @@
 ;;
 ;; `popper-mode-line': String or sexp to show in the mode-line of
 ;; popper. Setting this to nil removes the mode-line entirely from
-;; popper.
+;; popper. Set to `unmodified' to not modify the mode-line.
 ;;
 ;; `popper-group-function': Function that returns the context a popup
 ;; should be shown in. The context is a string or symbol used to group
@@ -118,10 +118,11 @@ fewer than 10 lines at time of creation."
 (defcustom popper-mode-line '(:eval (propertize " POP" 'face 'mode-line-emphasis))
   "String or sexp to show in the mode-line of popper.
 
- Can be a quoted list or function. Setting this to nil removes
+ Can be a quoted list, function, or `unmodified'. Setting this to nil removes
 the mode-line entirely from popper."
   :group 'popper
   :type '(choice (const :tag "Off" nil)
+                 (const :tage "Unmodified" unmodified)
                  (string :tag "Literal text")
                  (sexp :tag "General `mode-line-format' entry")))
 
@@ -387,9 +388,10 @@ Each element of the alist is a cons cell of the form (window . buffer)."
                        (append (list newpop)
                                (cl-remove newpop group-popups :key 'cdr))))))
     ;; Mode line update
-    (cl-loop for (_ . buf) in popper-open-popup-alist do
-             (with-current-buffer buf
-               (setq mode-line-format (popper--modified-mode-line))))))
+    (unless (eq popper-mode-line 'unmodified)
+      (cl-loop for (_ . buf) in popper-open-popup-alist do
+               (with-current-buffer buf
+		 (setq mode-line-format (popper--modified-mode-line)))))))
 
 (defun popper--find-buried-popups ()
   "Update the list of currently buried popups.


### PR DESCRIPTION
Add an option to disable modeline modifications. This is useful when using something like `doom-modeline`