### PR TITLE
Small fixes for popper-tab-line-mode

### DIFF
--- a/popper-echo.el
+++ b/popper-echo.el
@@ -87,8 +87,8 @@ NOTE: This feature is experimental."
   :type 'boolean
   :group 'popper)
 
-(defcustom popper-echo-dispatch-keys '("M-0" "M-1" "M-2" "M-3" "M-4"
-                                       "M-5" "M-6" "M-7" "M-8" "M-9")
+(defcustom popper-echo-dispatch-keys '("M-1" "M-2" "M-3" "M-4" "M-5"
+                                       "M-6" "M-7" "M-8" "M-9" "M-0")
   "List of keys used for dispatching to popup buffers.
 
 The first element is bound to the currently open popup.

--- a/popper-echo.el
+++ b/popper-echo.el
@@ -289,8 +289,12 @@ To define buffers as popups and customize popup display, see
     (if (not buried-popups)
         (tab-line-mode -1)
       (unless tab-line-mode
-        (setq-local tab-line-tabs-function (lambda () (cdr (popper-echo--popup-info)))
-                    tab-line-tab-name-format-function #'popper-tab-line--format)
+        (setq-local tab-line-tabs-function (lambda () (cons (cdar popper-open-popup-alist) (cdr (popper-echo--popup-info))))
+                    tab-line-tab-name-format-function #'popper-tab-line--format
+                    tab-line-close-tab-function (lambda (tab)
+                                                  (kill-buffer (if (bufferp tab) tab (cdr (assq 'buffer tab))))
+                                                  (unless (cdr (popper-echo--popup-info))
+                                                    (tab-line-mode -1))))
         (tab-line-mode 1)))
     (popper-echo--activate-keymap (cons open-popup buried-popups)
                                   #'popper-tab-line--ensure)))


### PR DESCRIPTION
Thanks for this! These are the changes I alluded to on discord.

~~I found that when activating `popper-tab-line-mode` the `rawkey` was being used as a string, I looked at the old code and adapted that for a new `strkey` local var.~~

Also the `popper-echo-dispatch-keys` var was ordered with `M-0` at the start, but then this key was being bound to index `0` with `M-1` being `1` and so on. While this makes the digits align it meant the displayed tab number (1-based) didn't align with the keybinds when I added the current buffer to the tab-line like `popper-echo-mode` does. It also didn't align with my intuition that `1` was the current tab and then they moved left to right as shown, with `0` being `10`.

I've also bound the var `tab-line-close-tab-function` to a lambda around `kill-buffer` so that they can be closed with the mouse. Previously the `x` did nothing.

The tab-line also doesn't appear when a popup is initially created. Although this also doesn't happen for `popper-echo-mode`.