### PR TITLE
Add directional popups

### DIFF
--- a/popper.el
+++ b/popper.el
@@ -4,7 +4,7 @@
 
 ;; Author: Karthik Chikmagalur <karthik.chikmagalur@gmail.com>
 ;; Version: 0.4.6
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "28.1"))
 ;; Keywords: convenience
 ;; URL: https://github.com/karthink/popper
 
@@ -76,6 +76,7 @@
   (require 'subr-x))
 (require 'cl-lib)
 (require 'seq)
+(require 'transient)
 
 (declare-function project-root "project")
 (declare-function project-current "project")
@@ -675,6 +676,36 @@ If BUFFER is not specified act on the current buffer instead."
     (pcase popup-status
       ((or 'popup 'user-popup) (popper-raise-popup buf))
       (_ (popper-lower-to-popup buf)))))
+
+(defun popper--toggle-type-selector (fn)
+  "Invoke `popper-toggle-type' with FN as `popper-display-function'."
+  (setq-local popper-display-function fn)
+  (popper-toggle-type))
+
+(transient-define-prefix popper-toggle-type-transient ()
+  "Popper toggle type transient."
+  [[("k" "top" (lambda ()
+                 (interactive)
+                 (popper--toggle-type-selector #'popper-select-popup-at-top)))]
+   [("j" "bottom" (lambda ()
+                    (interactive)
+                    (popper--toggle-type-selector #'popper-select-popup-at-bottom)))]
+   [("h" "left" (lambda ()
+                  (interactive)
+                  (popper--toggle-type-selector #'popper-select-popup-at-left)))]
+   [("l" "right" (lambda ()
+                   (interactive)
+                   (popper--toggle-type-selector #'popper-select-popup-at-right)))]])
+
+(defun popper-toggle-type-with-transient (&optional buffer)
+  "Like `popper-toggle-type' but asking for direction.
+If BUFFER is not specified act on the current buffer instead."
+  (interactive)
+  (let* ((buf (get-buffer (or buffer (current-buffer))))
+         (popup-status (buffer-local-value 'popper-popup-status buf)))
+    (pcase popup-status
+      ((or 'popup 'user-popup) (popper-raise-popup buf))
+      (_ (popper-toggle-type-transient)))))
 
 (defun popper-kill-latest-popup ()
   "Kill the latest popup-buffer and delete its window."

--- a/popper.el
+++ b/popper.el
@@ -163,6 +163,15 @@ action alist and displays the buffer.  See (info \"(elisp) Buffer
 Display Action Alists\") for details on the alist."
   :type 'function)
 
+(defcustom popper-display-action '()
+  "Action to use to display popper.
+
+ Note that this is only used when
+`popper-display-control' is non-nil.
+
+See (info \"(elisp) Buffer Display Action Alists\") for details on the alist."
+  :type 'list)
+
 (defcustom popper-group-function nil
   "Function that returns a popup context.
 
@@ -736,7 +745,8 @@ types as popups."
         (add-hook 'window-configuration-change-hook #'popper--update-popups)
         (add-hook 'select-frame-hook #'popper--update-popups)
         (add-to-list 'display-buffer-alist
-                     '(popper-display-control-p popper-select-popup)))
+                     `(popper-display-control-p popper-select-popup
+                       ,@popper-display-action)))
     ;; Turning the mode OFF
     (remove-hook 'window-configuration-change-hook #'popper--update-popups)
     (remove-hook 'window-configuration-change-hook #'popper--suppress-popups)

--- a/popper.el
+++ b/popper.el
@@ -307,9 +307,10 @@ such alists."
              (slot . 1)))))
 
 (defun popper-select-popup (buffer &optional alist)
-  "Invoke the popper-select function configured in `popper-display-function'.
+  "Invoke `popper-display-function' locally bound in BUFFER.
 For the meaning of BUFFER and ALIST read `popper-select-popup-at-bottom'."
-  (funcall popper-display-function buffer alist))
+  (with-current-buffer buffer
+    (funcall popper-display-function buffer alist)))
 
 (defun popper-popup-p (buf)
   "Predicate to test if buffer BUF qualifies for popper handling.

--- a/popper.el
+++ b/popper.el
@@ -262,16 +262,40 @@ Valid values are \\='popup, \\='raised, \\='user-popup or nil.
    (floor (frame-height) 3)
    (floor (frame-height) 6)))
 
+(defun popper-select-popup-at-top (buffer &optional alist)
+  "Display and switch to popup-buffer BUFFER at the top of the screen.
+ALIST is an association list of action symbols and values.  See
+Info node `(elisp) Buffer Display Action Alists' for details of
+such alists."
+  (let ((window (popper-display-popup-at-dir buffer 'top alist)))
+    (select-window window)))
+
 (defun popper-select-popup-at-bottom (buffer &optional alist)
   "Display and switch to popup-buffer BUFFER at the bottom of the screen.
 ALIST is an association list of action symbols and values.  See
 Info node `(elisp) Buffer Display Action Alists' for details of
 such alists."
-  (let ((window (popper-display-popup-at-bottom buffer alist)))
+  (let ((window (popper-display-popup-at-dir buffer 'bottom alist)))
     (select-window window)))
 
-(defun popper-display-popup-at-bottom (buffer &optional alist)
-  "Display popup-buffer BUFFER at the bottom of the screen.
+(defun popper-select-popup-at-left (buffer &optional alist)
+  "Display and switch to popup-buffer BUFFER at the left of the screen.
+ALIST is an association list of action symbols and values.  See
+Info node `(elisp) Buffer Display Action Alists' for details of
+such alists."
+  (let ((window (popper-display-popup-at-dir buffer 'left alist)))
+    (select-window window)))
+
+(defun popper-select-popup-at-right (buffer &optional alist)
+  "Display and switch to popup-buffer BUFFER at the right of the screen.
+ALIST is an association list of action symbols and values.  See
+Info node `(elisp) Buffer Display Action Alists' for details of
+such alists."
+  (let ((window (popper-display-popup-at-dir buffer 'right alist)))
+    (select-window window)))
+
+(defun popper-display-popup-at-dir (buffer dir &optional alist)
+  "Display popup-buffer BUFFER as a side window in DIR.
 ALIST is an association list of action symbols and values.  See
 Info node `(elisp) Buffer Display Action Alists' for details of
 such alists."
@@ -279,8 +303,13 @@ such alists."
    buffer
    (append alist
            `((window-height . ,popper-window-height)
-             (side . bottom)
+             (side . ,dir)
              (slot . 1)))))
+
+(defun popper-select-popup (buffer &optional alist)
+  "Invoke the popper-select function configured in `popper-display-function'.
+For the meaning of BUFFER and ALIST read `popper-select-popup-at-bottom'."
+  (funcall popper-display-function buffer alist))
 
 (defun popper-popup-p (buf)
   "Predicate to test if buffer BUF qualifies for popper handling.
@@ -706,8 +735,7 @@ types as popups."
         (add-hook 'window-configuration-change-hook #'popper--update-popups)
         (add-hook 'select-frame-hook #'popper--update-popups)
         (add-to-list 'display-buffer-alist
-                     `(popper-display-control-p
-                       (,popper-display-function))))
+                     '(popper-display-control-p popper-select-popup)))
     ;; Turning the mode OFF
     (remove-hook 'window-configuration-change-hook #'popper--update-popups)
     (remove-hook 'window-configuration-change-hook #'popper--suppress-popups)


### PR DESCRIPTION
Hello, here are a few changes I've been using in my fork of popper that I thing would be of interest.

New features added:
- Addition of a transient interface to interactively select in which direction the user wants to display the popups.
- Popper will try to fit popups in free slots of the selected side of the window respecting `max-side-slots'.
- Allow the user to configure the display actions used by `popper-display-function' via the user configurable variable `popper-display-action'.
- Allow the run time configuration of `popper-display-function', this is required for the dynamic transient interface but could be used for other functionality such as modifying the way popper handles the display of popups according to the context.

Directional popups screenshot:
![popper-directional-popups](https://github.com/karthink/popper/assets/54212424/85fda74e-b4a9-447b-970d-a427dcbffba2)